### PR TITLE
Add AUTH_LDAP_SENTRY_SUBSCRIBE_BY_DEFAULT to prevent spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ Member type auto-added users are assigned. Valid values are 'MEMBER', 'ADMIN', '
 AUTH_LDAP_SENTRY_ORGANIZATION_GLOBAL_ACCESS = True
 ```
 Whether auto-created users should be granted global access within the default organization.
-
+ 
+```Python
+AUTH_LDAP_SENTRY_SUBSCRIBE_BY_DEFAULT = False
+```
+Whether new users should be subscribed to any new projects by default. Disabling
+this is useful for large organizations where a subscription to each project
+might be spammy.
+ 
 ### Sentry Options
 
 ```Python

--- a/sentry_ldap_auth/backend.py
+++ b/sentry_ldap_auth/backend.py
@@ -35,18 +35,18 @@ class SentryLdapBackend(LDAPBackend):
         if not organizations or len(organizations) < 1:
             return model
 
-        if settings.AUTH_LDAP_SENTRY_ORGANIZATION_MEMBER_TYPE:
+        if getattr(settings, 'AUTH_LDAP_SENTRY_ORGANIZATION_MEMBER_TYPE', None):
             member_type = getattr(OrganizationMemberType, settings.AUTH_LDAP_SENTRY_ORGANIZATION_MEMBER_TYPE)
         else:
             member_type = OrganizationMemberType.MEMBER
 
-        if settings.AUTH_LDAP_SENTRY_ORGANIZATION_GLOBAL_ACCESS:
+        if getattr(settings, 'AUTH_LDAP_SENTRY_ORGANIZATION_GLOBAL_ACCESS', False):
             has_global_access = True
         else:
             has_global_access = False
 
         # Add the user to the organization with global access
-        member = OrganizationMember.objects.create(
+        OrganizationMember.objects.create(
             organization=organizations[0],
             type=member_type,
             has_global_access=has_global_access,
@@ -54,9 +54,9 @@ class SentryLdapBackend(LDAPBackend):
             flags=getattr(OrganizationMember.flags, 'sso:linked'),
         )
 
-        if not settings.AUTH_LDAP_SENTRY_SUBSCRIBE_BY_DEFAULT:
+        if not getattr(settings, 'AUTH_LDAP_SENTRY_SUBSCRIBE_BY_DEFAULT', True):
             UserOption.objects.set_value(
-                user=member.user,
+                user=user,
                 project=None,
                 key='subscribe_by_default',
                 value='0',


### PR DESCRIPTION
First off, thanks for the code! It's been very useful.

One thing that'd really help us out is if we could disable project subscription by default... we have a pretty big org and a huge number of repos, so having everyone subscribed to every new project by default creates a lot of spam for most people.

This PR adds an option to disable subscriptions to new projects by default.

Thanks again for the project.
