### PR TITLE
Role refactor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ AUTH_LDAP_DEFAULT_SENTRY_ORGANIZATION = u'My Organization Name'
 Auto adds created user to the specified organization (matched by name) if it exists.
 
 ```Python
-AUTH_LDAP_SENTRY_ORGANIZATION_MEMBER_TYPE = 'MEMBER'
+AUTH_LDAP_SENTRY_ORGANIZATION_ROLE_TYPE = 'member'
 ```
-Member type auto-added users are assigned. Valid values are 'MEMBER', 'ADMIN', 'OWNER'.
+Role type auto-added users are assigned. Valid values in a default installation of Sentry are 'member', 'admin', 'manager' & 'owner'. However, custom roles can also be added to Sentry, in which case these are also valid.
 
 ```Python
 AUTH_LDAP_SENTRY_ORGANIZATION_GLOBAL_ACCESS = True
@@ -78,7 +78,7 @@ AUTH_LDAP_CACHE_GROUPS = True
 AUTH_LDAP_GROUP_CACHE_TIMEOUT = 3600
 
 AUTH_LDAP_DEFAULT_SENTRY_ORGANIZATION = u'My Organization Name'
-AUTH_LDAP_SENTRY_ORGANIZATION_MEMBER_TYPE = 'MEMBER'
+AUTH_LDAP_SENTRY_ORGANIZATION_ROLE_TYPE = 'member'
 AUTH_LDAP_SENTRY_ORGANIZATION_GLOBAL_ACCESS = True
 
 AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + (

--- a/sentry_ldap_auth/backend.py
+++ b/sentry_ldap_auth/backend.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from sentry.models import (
     Organization,
     OrganizationMember,
-    OrganizationMemberType,
     UserOption,
 )
 
@@ -35,22 +34,15 @@ class SentryLdapBackend(LDAPBackend):
         if not organizations or len(organizations) < 1:
             return model
 
-        if getattr(settings, 'AUTH_LDAP_SENTRY_ORGANIZATION_MEMBER_TYPE', None):
-            member_type = getattr(OrganizationMemberType, settings.AUTH_LDAP_SENTRY_ORGANIZATION_MEMBER_TYPE)
-        else:
-            member_type = OrganizationMemberType.MEMBER
-
-        if getattr(settings, 'AUTH_LDAP_SENTRY_ORGANIZATION_GLOBAL_ACCESS', False):
-            has_global_access = True
-        else:
-            has_global_access = False
+        member_role = getattr(settings, 'AUTH_LDAP_SENTRY_ORGANIZATION_ROLE_TYPE', 'member')
+        has_global_access = getattr(settings, 'AUTH_LDAP_SENTRY_ORGANIZATION_GLOBAL_ACCESS', False)
 
         # Add the user to the organization with global access
         OrganizationMember.objects.create(
             organization=organizations[0],
-            type=member_type,
-            has_global_access=has_global_access,
             user=user,
+            role=member_role,
+            has_global_access=has_global_access,
             flags=getattr(OrganizationMember.flags, 'sso:linked'),
         )
 


### PR DESCRIPTION
A huge refactor of Sentry's handling of roles landed in early November: The Great Role Refactor. This breaks compatibility with Sentry releases after this commit, including the recently released 8.0.0-rc1.

Here's an attempt to support both the new role system (v8.x or newer) and the old member type system (v7.x or older). Seems to work well on our Sentry 8.0.0-rc1 installation, and should work on older Sentry installations, but I freely admit I haven't tested the latter as I have no such installation handy to test with.

This would potentially resolve #3 if it's to the maintainer's satisfaction!
