### PR TITLE
Populate sentry_useremail with email address

### DIFF
--- a/sentry_ldap_auth/backend.py
+++ b/sentry_ldap_auth/backend.py
@@ -6,7 +6,6 @@ from sentry.models import (
     Organization,
     OrganizationMember,
     UserOption,
-    UserEmail
 )
 
 
@@ -20,10 +19,15 @@ class SentryLdapBackend(LDAPBackend):
 
         user.is_managed = True
 
-        UserEmail.objects.update(
-            user=user,
-            email=ldap_user.attrs.get('mail', ' ')[0] or '',
-        )
+        try:
+            from sentry.models import (UserEmail)
+        except ImportError:
+            pass
+        else:
+            UserEmail.objects.update(
+                user=user,
+                email=ldap_user.attrs.get('mail', ' ')[0] or '',
+            )
 
         # Check to see if we need to add the user to an organization
         if not settings.AUTH_LDAP_DEFAULT_SENTRY_ORGANIZATION:

--- a/sentry_ldap_auth/backend.py
+++ b/sentry_ldap_auth/backend.py
@@ -6,6 +6,7 @@ from sentry.models import (
     Organization,
     OrganizationMember,
     UserOption,
+    UserEmail
 )
 
 
@@ -18,6 +19,11 @@ class SentryLdapBackend(LDAPBackend):
         user = model[0]
 
         user.is_managed = True
+
+        UserEmail.objects.update(
+            user=user,
+            email=ldap_user.attrs.get('mail', ' ')[0] or '',
+        )
 
         # Check to see if we need to add the user to an organization
         if not settings.AUTH_LDAP_DEFAULT_SENTRY_ORGANIZATION:


### PR DESCRIPTION
## Summary

Email verification was added in Sentry Server 8.6, which uses a new table named `sentry_useremail` to store email addresses for verification rather than using the email address already in the `auth_user` table. This updates the sentry-ldap-auth plugin so the `sentry_useremail` table is populated with the value of the LDAP user's `mail` attribute.

Fixes #11 
## How to test
1. With an instance of Sentry Server 8.6 or higher, `pip install git+https://github.com/Banno/getsentry-ldap-auth.git@populate-useremail`
2. Log in with an LDAP user's credentials
3. Query the `sentry_useremail` table to verify that the e-mail address is populated as expected
# Notes
- This has been made backward-compatible with Sentry Server versions before 8.6, so no exceptions are thrown due to the lack of the `sentry.models.UserEmail` model
