### PR TITLE
Fix sentry_useremail "duplicate key" error

### DIFF
--- a/sentry_ldap_auth/backend.py
+++ b/sentry_ldap_auth/backend.py
@@ -24,10 +24,12 @@ class SentryLdapBackend(LDAPBackend):
         except ImportError:
             pass
         else:
-            UserEmail.objects.update(
-                user=user,
-                email=ldap_user.attrs.get('mail', ' ')[0] or '',
-            )
+            userEmail = UserEmail.objects.get(user=user)
+            if not userEmail:
+                userEmail = UserEmail.objects.create(user=user)
+
+            userEmail.email=ldap_user.attrs.get('mail', ' ')[0] or ''
+            userEmail.save()
 
         # Check to see if we need to add the user to an organization
         if not settings.AUTH_LDAP_DEFAULT_SENTRY_ORGANIZATION:


### PR DESCRIPTION
## Summary

This reworks #13 to fix #15, a `duplicate key value violates unique constraint` error when updating the `sentry_useremail` table upon LDAP authentication when there is more than one record in the `sentry_useremail` table.
