### PR TITLE
Added a setting to allow user to override what field is used as the username

### DIFF
--- a/sentry_ldap_auth/backend.py
+++ b/sentry_ldap_auth/backend.py
@@ -11,6 +11,14 @@ from sentry.models import (
 
 class SentryLdapBackend(LDAPBackend):
     def get_or_create_user(self, username, ldap_user):
+        username_field = getattr(settings, 'AUTH_LDAP_SENTRY_USERNAME_FIELD', '')
+        if username_field:
+            # pull the username out of the ldap_user info
+            if ldap_user and username_field in ldap_user.attrs:
+                username = ldap_user.attrs[username_field]
+                if isinstance(username, (list, tuple)):
+                    username = username[0]
+
         model = super(SentryLdapBackend, self).get_or_create_user(username, ldap_user)
         if len(model) < 1:
             return model


### PR DESCRIPTION
I'm using this to connect to Active Directory and with a basic setup logging in with basic username (e.g. user) vs using an email (e.g. user@company.com) ends up creating two separate users in Sentry. This really looks like something that could be more useful in django-ldap-auth, so if people agree we could push it up stream, but this was a quick fix/work around for what I need right now. 

Essentially, it let's you set `AUTH_LDAP_SENTRY_USERNAME_FIELD` in your sentry settings, then `get_or_create_user` will lookup the username from `ldap_user.attrs` rather than use the username that was supplied in the login info. The end result is that you only get one user created no matter what selectors you have for LDAP. 

Note, you must set your `AUTH_LDAP_USER_SEARCH` in settings so that the correct record will be selected for each value you want to be valid in the username login field. For example, if you want username and email to work for login, you can use the following for Active Directory:

```
AUTH_LDAP_SENTRY_USERNAME_FIELD = 'sAMAccountName'
AUTH_LDAP_USER_SEARCH = LDAPSearch(
     'dc=company,dc=com', 
     ldap.SCOPE_SUBTREE, 
     '(|(sAMAccountName=%(user)s)(mail=%(user)s))'
)
```