### PR TITLE
add default value for AUTH_LDAP_SENTRY_GROUP_ROLE_MAPPING

### DIFF
--- a/sentry_ldap_auth/backend.py
+++ b/sentry_ldap_auth/backend.py
@@ -18,7 +18,7 @@ def _get_effective_sentry_role(group_names):
         'owner',
     ]
 
-    role_mapping = getattr(settings, 'AUTH_LDAP_SENTRY_GROUP_ROLE_MAPPING')
+    role_mapping = getattr(settings, 'AUTH_LDAP_SENTRY_GROUP_ROLE_MAPPING', None)
 
     if not group_names or not role_mapping:
         return None


### PR DESCRIPTION
Not having a default value for this settings break sentry installation for application not expecting to have this, especially if they rely on semver.  