### PR TITLE
Add readme for support for sentry 10.0.0, up requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ A Django custom authentication backend for [Sentry](https://github.com/getsentry
 Versions 2.0 and newer require Sentry 8. For Sentry 7 support, use [the 1.1 release](https://github.com/Banno/getsentry-ldap-auth/releases/tag/1.1)
 
 ## Installation
-To install, simply add `sentry-ldap-auth` to your *requirements.txt* for your Sentry environment (or `pip install sentry-ldap-auth`).
-
+To install, simply add `sentry-ldap-auth` to your *requirements.txt* in your Sentry environment 
+and install gcc in your *Dockerfile* in the same config 
+```shell script
+RUN apt-get update && apt-get install -y gcc
+```
 ## Configuration
-This module extends the [django-auth-ldap](https://django-auth-ldap.readthedocs.io/en/latest/) and all the options it provides are supported (up to v1.2.x, at least). 
+This module extends the [django-auth-ldap](https://django-auth-ldap.readthedocs.io/en/latest/) and almost all the options are supported (up until 1.7.*)
+One options that's not supported is `AUTH_LDAP_MIRROR_GROUPS` .
 
 To configure Sentry to use this module, add `sentry_ldap_auth.backend.SentryLdapBackend` to your `AUTHENTICATION_BACKENDS` in your *sentry.conf.py*, like this:
 

--- a/sentry_ldap_auth/backend.py
+++ b/sentry_ldap_auth/backend.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-from django_auth_ldap.backend import LDAPBackend
 from django.conf import settings
 from django.db.models import Q
+from django_auth_ldap.backend import LDAPBackend
 from sentry.models import (
     Organization,
     OrganizationMember,
@@ -34,7 +34,7 @@ def _get_effective_sentry_role(group_names):
 
 
 class SentryLdapBackend(LDAPBackend):
-    def get_or_create_user(self, username, ldap_user):
+    def get_or_build_user(self, username, ldap_user):
         username_field = getattr(settings, 'AUTH_LDAP_SENTRY_USERNAME_FIELD', '')
         if username_field:
             # pull the username out of the ldap_user info
@@ -43,7 +43,7 @@ class SentryLdapBackend(LDAPBackend):
                 if isinstance(username, (list, tuple)):
                     username = username[0]
 
-        model = super(SentryLdapBackend, self).get_or_create_user(username, ldap_user)
+        model = super(SentryLdapBackend, self).get_or_build_user(username, ldap_user)
         if len(model) < 1:
             return model
 

--- a/sentry_ldap_auth/backend.py
+++ b/sentry_ldap_auth/backend.py
@@ -67,6 +67,7 @@ class SentryLdapBackend(LDAPBackend):
             # django-auth-ldap may have accidentally created an empty email address
             UserEmail.objects.filter(Q(email='') | Q(email=' '), user=user).delete()
             if email:
+                user.save()  # Save to avoid unsaved related object value error
                 UserEmail.objects.get_or_create(user=user, email=email)
 
         # Check to see if we need to add the user to an organization

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ with open("README.md", "r") as readme:
     long_description = readme.read()
 
 install_requires = [
-    'django-auth-ldap==1.2.*',
-    'sentry>=8.0.0',
+    'django-auth-ldap==1.7.*',  # Last version to support Python 2.7
+    'sentry>=10.0.0',
 ]
 
 setup(


### PR DESCRIPTION
Had to change signature to support newer version of django-auth-ldap

Tested minimally. Only thing I saw while testing with setup I normally use is this :
```
File "/usr/local/lib/python2.7/site-packages/sentry/web/forms/accounts.py", line 132, in clean
  self.user_cache = authenticate(username=username, password=password)
File "/usr/local/lib/python2.7/site-packages/django/contrib/auth/__init__.py", line 70, in authenticate
  user = _authenticate_with_backend(backend, backend_path, request, credentials)
File "/usr/local/lib/python2.7/site-packages/django/contrib/auth/__init__.py", line 116, in _authenticate_with_backend
  return backend.authenticate(*args, **credentials)
File "/usr/local/lib/python2.7/site-packages/django_auth_ldap/backend.py", line 150, in authenticate
  user = self.authenticate_ldap_user(ldap_user, password)
File "/usr/local/lib/python2.7/site-packages/django_auth_ldap/backend.py", line 210, in authenticate_ldap_user
  return ldap_user.authenticate(password)
File "/usr/local/lib/python2.7/site-packages/django_auth_ldap/backend.py", line 350, in authenticate
  self._get_or_create_user()
File "/usr/local/lib/python2.7/site-packages/django_auth_ldap/backend.py", line 617, in _get_or_create_user
  self._mirror_groups()
File "/usr/local/lib/python2.7/site-packages/django_auth_ldap/backend.py", line 720, in _mirror_groups
  current_group_names = frozenset(self._user.groups.values_list('name', flat=True).iterator())
tributeError: 'User' object has no attribute 'groups'
```
Which is a result of the AUTH_LDAP_MIRROR_GROUPS option