### PR TITLE
fix(role_mapping): add support for python 3

### DIFF
--- a/sentry_ldap_auth/backend.py
+++ b/sentry_ldap_auth/backend.py
@@ -23,7 +23,7 @@ def _get_effective_sentry_role(group_names):
     if not group_names or not role_mapping:
         return None
 
-    applicable_roles = [role for role, groups in role_mapping.iteritems() if group_names.intersection(groups)]
+    applicable_roles = [role for role, groups in role_mapping.items() if group_names.intersection(groups)]
 
     if not applicable_roles:
         return None


### PR DESCRIPTION
Replaced iteritems() function with items(), which works on Python 3 (and Python 2, source: https://python-future.org/compatible_idioms.html)

Tested on Sentry 21.1.0 (onpremise).