### PR TITLE
Deprecate in favor of sentry-auth-ldap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # sentry-ldap-auth
 
+> This module is deprecated in favor of [sentry-auth-ldap](https://pypi.org/project/sentry-auth-ldap),
+> a fork of this project maintained at https://github.com/PMExtra/sentry-auth-ldap.
+
 A Django custom authentication backend for [Sentry](https://github.com/getsentry/sentry). This module extends the functionality of [django-auth-ldap](https://github.com/django-auth-ldap/django-auth-ldap) with Sentry specific features.
 
 ## Features


### PR DESCRIPTION
Thanks for this project.

Due to its popularity and continued activity in GitHub issues, it is still the first Google result when searching for LDAP integration for Sentry. However, this project has not been maintained for a couple of years and no longer works with recent versions of Sentry.

https://github.com/PMExtra/sentry-auth-ldap has hard-forked this project, re-published the module as https://pypi.org/project/sentry-auth-ldap
and is continously maintaining it. Thus, I believe it is valuable to include this deprecation notice, link to the fork in the description, and then archive this project.